### PR TITLE
feat: add monitoring capabilities with metrics integration

### DIFF
--- a/rag/pom.xml
+++ b/rag/pom.xml
@@ -13,14 +13,12 @@
     <artifactId>rag</artifactId>
     <version>0.1-SNAPSHOT</version>
 
-
     <name>rag</name>
 
     <properties>
         <java.version>17</java.version>
         <aws.sdk.version>2.29.43</aws.sdk.version>
         <spring-boot.version>3.4.1</spring-boot.version>
-
         <micrometer.version>1.14.2</micrometer.version>
         <docker.registry>fabianaguero</docker.registry>
         <docker.username>fabianaguero</docker.username>
@@ -34,7 +32,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <!-- Fuerza Jetty 9.4.51 para todas las dependencias -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>9.4.51.v20230217</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Spring Boot starters y utilidades varias... -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -51,67 +63,70 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
-
-
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.3.0</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- LangChain4j y otros módulos -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
             <version>${langchain4j.version}</version>
         </dependency>
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
             <version>${langchain4j.version}</version>
         </dependency>
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-pgvector</artifactId>
             <version>${langchain4j-pgvector.version}</version>
         </dependency>
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-ollama</artifactId>
             <version>${langchain4j.version}</version>
         </dependency>
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings</artifactId>
             <version>${langchain4j.version}</version>
         </dependency>
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-qdrant</artifactId>
             <version>${langchain4j.version}</version>
         </dependency>
 
-
+        <!-- Micrometer/Actuator -->
         <dependency>
-            <groupId>com.microsoft.onnxruntime</groupId>
-            <artifactId>onnxruntime</artifactId>
-            <version>${onnxruntime.version}</version>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-dynatrace</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
         </dependency>
 
+        <!-- Postgres -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
 
+        <!-- Jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -121,32 +136,82 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
+        <!-- Otros utilitarios -->
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <version>2.0.29</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.mapdb</groupId>
-            <artifactId>mapdb</artifactId>
-            <version>${mapdb.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>ai.djl.huggingface</groupId>
             <artifactId>tokenizers</artifactId>
             <version>0.22.1</version>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
-
             <scope>provided</scope>
         </dependency>
 
+        <!-- Dependencias Jetty requeridas por WireMock en runtime -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+        </dependency>
+
+        <!-- WireMock (solo versión 2.35.0, con exclusión de http2-server) -->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.http2</groupId>
+                    <artifactId>http2-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-http2-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Servlets para Spring Boot y compatibilidad -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -176,6 +241,10 @@
     </build>
 
     <repositories>
+        <repository>
+            <id>dynatrace</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
         <repository>
             <id>langchain4j</id>
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>

--- a/rag/src/main/java/org/shark/evolvai/embedding/adapter/in/rest/EmbeddingController.java
+++ b/rag/src/main/java/org/shark/evolvai/embedding/adapter/in/rest/EmbeddingController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.shark.evolvai.config.RagProperties;
 import org.shark.evolvai.embedding.port.in.EmbeddingUseCase;
+import org.shark.evolvai.metrics.MonitoredEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -58,6 +59,7 @@ public class EmbeddingController {
             }
     )
     @PostMapping("/upload")
+    @MonitoredEndpoint(name = "api.embedding.upload" )
     public ResponseEntity<?> uploadDocument(@RequestParam("file") MultipartFile file) {
         try {
             String filename = file.getOriginalFilename();
@@ -102,6 +104,7 @@ public class EmbeddingController {
 
 
     @PostMapping("/index")
+    @MonitoredEndpoint(name = "api.embedding.index" )
     public ResponseEntity<Void> indexDocument(@RequestBody DocumentRequest request) {
         String id = request.getId() != null ? request.getId() : UUID.randomUUID().toString();
         embeddingUseCase.indexDocument(id, request.getText(), request.getCustomPrompt());
@@ -109,6 +112,7 @@ public class EmbeddingController {
     }
 
     @GetMapping("/search")
+    @MonitoredEndpoint(name = "api.embedding.search" )
     public ResponseEntity<List<String>> search(
             @RequestParam String query,
             @RequestParam(required = false) Integer maxResults,
@@ -120,6 +124,7 @@ public class EmbeddingController {
     }
 
     @GetMapping("/documents")
+    @MonitoredEndpoint(name = "api.embedding.documents" )
     public ResponseEntity<List<String>> listDocuments() {
         log.info("Recibida solicitud para listar document_id distintos.");
         List<String> ids = embeddingUseCase.listDocumentIds();
@@ -132,6 +137,7 @@ public class EmbeddingController {
             summary = "Elimina todos los embeddings del almacenamiento",
             description = "Borra todos los embeddings actualmente almacenados en PgVector u otro backend configurado."
     )
+    @MonitoredEndpoint(name = "api.embedding.remove-all" )
     public ResponseEntity<String> removeAllEmbeddings() {
         try {
             embeddingUseCase.removeAllDocuments();

--- a/rag/src/main/java/org/shark/evolvai/inference/adapter/in/rest/InferenceController.java
+++ b/rag/src/main/java/org/shark/evolvai/inference/adapter/in/rest/InferenceController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import org.shark.evolvai.inference.controller.QueryResponse;
 import org.shark.evolvai.inference.controller.RagQueryRequest;
 import org.shark.evolvai.inference.port.input.InferenceUseCase;
+import org.shark.evolvai.metrics.MonitoredEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +52,7 @@ public class InferenceController {
                     @ApiResponse(responseCode = "400", description = "Solicitud inválida")
             }
     )
+    @MonitoredEndpoint(name = "api.inference.query" )
     public ResponseEntity<QueryResponse> query(
             @Parameter(description = "Datos de la consulta", required = true)
             @Valid @RequestBody RagQueryRequest request) {
@@ -74,6 +76,7 @@ public class InferenceController {
                     @ApiResponse(responseCode = "400", description = "Solicitud inválida")
             }
     )
+    @MonitoredEndpoint(name = "api.inference.advancedQuery" )
     public ResponseEntity<QueryResponse> advancedQuery(
             @Parameter(description = "Datos de la consulta avanzada", required = true)
             @Valid @RequestBody RagQueryRequest request) {

--- a/rag/src/main/java/org/shark/evolvai/llm/adapter/in/rest/LlmPromptController.java
+++ b/rag/src/main/java/org/shark/evolvai/llm/adapter/in/rest/LlmPromptController.java
@@ -3,6 +3,7 @@ package org.shark.evolvai.llm.adapter.in.rest;
 import lombok.RequiredArgsConstructor;
 
 import org.shark.evolvai.config.RagProperties;
+import org.shark.evolvai.metrics.MonitoredEndpoint;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,6 +17,7 @@ public class LlmPromptController {
     private String overridePrompt;
 
     @GetMapping("/prompt")
+    @MonitoredEndpoint(name = "api.llm.getPrompt" )
     public ResponseEntity<String> getPrompt() {
         String prompt = (overridePrompt != null && !overridePrompt.isBlank())
                 ? overridePrompt
@@ -24,12 +26,14 @@ public class LlmPromptController {
     }
 
     @PostMapping("/prompt")
+    @MonitoredEndpoint(name = "api.llm.setPrompt")
     public ResponseEntity<Void> setPrompt(@RequestBody String newPrompt) {
         this.overridePrompt = newPrompt.trim();
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/prompt")
+    @MonitoredEndpoint(name = "api.llm.resetPrompt")
     public ResponseEntity<Void> resetPrompt() {
         this.overridePrompt = null;
         return ResponseEntity.ok().build();

--- a/rag/src/main/java/org/shark/evolvai/metrics/MonitoredEndpointAspect.java
+++ b/rag/src/main/java/org/shark/evolvai/metrics/MonitoredEndpointAspect.java
@@ -24,6 +24,7 @@ public class MonitoredEndpointAspect {
     private final MeterRegistry meterRegistry;
 
     @Around("@annotation(MonitoredEndpoint)")
+
     public Object measureExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
         MonitoredEndpoint annotation = method.getAnnotation(MonitoredEndpoint.class);
@@ -40,8 +41,10 @@ public class MonitoredEndpointAspect {
             throw ex;
         } finally {
             long end = System.nanoTime();
-            double durationSeconds = (end - start) / 1_000_000_000.0;
-            meterRegistry.timer("http.endpoint.duration", Tags.of("endpoint", endpointName)).record((long) durationSeconds, java.util.concurrent.TimeUnit.SECONDS);
+            long durationMillis = (end - start) / 1_000_000;
+            meterRegistry.timer("http.endpoint.duration", Tags.of("endpoint", endpointName))
+                    .record(durationMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
         }
     }
+
 }

--- a/rag/src/main/java/org/shark/evolvai/metrics/MonitoringSummaryController.java
+++ b/rag/src/main/java/org/shark/evolvai/metrics/MonitoringSummaryController.java
@@ -1,0 +1,72 @@
+package org.shark.evolvai.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Endpoint de monitoreo unificado para métricas de los endpoints core.
+ * Devuelve la cantidad de llamadas y el tiempo total de cada controller principal.
+ */
+@RestController
+@RequestMapping("/api/monitoring")
+@RequiredArgsConstructor
+public class MonitoringSummaryController {
+
+    private final MeterRegistry meterRegistry;
+
+    @GetMapping("/summary")
+    public ResponseEntity<Map<String, Object>> getSummary() {
+        Map<String, Object> summary = new HashMap<>();
+        summary.put("embedding", getStatsFromMeters("api.embedding.documents"));
+        summary.put("inference", getStatsFromMeters("api.inference.query"));
+        summary.put("llm", getStatsFromMeters("api.llm.getPrompt"));
+        return ResponseEntity.ok(summary);
+    }
+
+    /**
+     * Recorre todos los meters del registry y filtra por nombre y tag "endpoint".
+     * Esto es compatible con todos los backends de Micrometer y asegura que no importa
+     * cómo se registró el timer, siempre encuentra los datos correctos.
+     */
+    private Map<String, Object> getStatsFromMeters(String endpointName) {
+        Map<String, Object> stats = new HashMap<>();
+        double count = 0, total = 0;
+        for (io.micrometer.core.instrument.Meter meter : meterRegistry.getMeters()) {
+            io.micrometer.core.instrument.Meter.Id id = meter.getId();
+            if ("http.endpoint.duration".equals(id.getName()) && endpointName.equals(id.getTag("endpoint"))) {
+                for (io.micrometer.core.instrument.Measurement m : meter.measure()) {
+                    if (m.getStatistic().name().equalsIgnoreCase("COUNT")) count = m.getValue();
+                    if (m.getStatistic().name().equalsIgnoreCase("TOTAL_TIME")) total = m.getValue();
+                }
+            }
+        }
+        double mean = count > 0 ? total / count : 0;
+        stats.put("calls", (long) count);
+        stats.put("total_milliseconds", total + " ms");
+        stats.put("mean_milliseconds", mean + " ms");
+        return stats;
+    }
+
+
+    /**
+     * Endpoint para debug: muestra todos los tags de endpoint registrados actualmente.
+     */
+    @GetMapping("/debug")
+    public ResponseEntity<List<String>> debugEndpoints() {
+        List<String> endpoints = meterRegistry.getMeters()
+                .stream()
+                .filter(m -> "http.endpoint.duration".equals(m.getId().getName()))
+                .map(m -> m.getId().getTag("endpoint"))
+                .distinct()
+                .toList();
+        return ResponseEntity.ok(endpoints);
+    }
+}

--- a/rag/src/main/java/org/shark/evolvai/metrics/README.md
+++ b/rag/src/main/java/org/shark/evolvai/metrics/README.md
@@ -1,0 +1,166 @@
+# Monitoreo y Métricas — Proyecto evolvAI
+
+Este módulo expone y recolecta métricas de los endpoints críticos usando [Micrometer](https://micrometer.io/) y Spring Boot Actuator, con soporte para Prometheus y Dynatrace.
+
+---
+
+## Endpoints de Métricas
+
+* **Prometheus:**
+  Acceso a todas las métricas:
+
+  ```
+  http://localhost:8081/actuator/prometheus
+  ```
+* **Micrometer/Actuator:**
+  Lista de métricas:
+
+  ```
+  http://localhost:8081/actuator/metrics
+  ```
+
+  Detalle de métrica:
+
+  ```
+  http://localhost:8081/actuator/metrics/http.endpoint.duration
+  ```
+
+---
+
+## Métricas Custom por Controller
+
+Se instrumentan con la annotation `@MonitoredEndpoint` en los siguientes controllers principales:
+
+* **EmbeddingController** `/api/embeddings`
+* **InferenceController** `/api/inference`
+* **LlmPromptController** `/api/llm`
+
+### Ejemplo de métricas expuestas
+
+```text
+# HELP http_endpoint_duration_seconds
+# TYPE http_endpoint_duration_seconds summary
+http_endpoint_duration_seconds_count{endpoint="api.embedding.documents"} 3
+http_endpoint_duration_seconds_count{endpoint="api.inference.query"} 7
+http_endpoint_duration_seconds_count{endpoint="api.llm.getPrompt"} 5
+# ...
+```
+
+* **endpoint:** Tag con el nombre lógico del endpoint instrumentado (definido en cada controller con `@MonitoredEndpoint(name = "...")`).
+* **Unidad:** Las duraciones están ahora registradas y reportadas en **milisegundos** para máxima precisión (antes era en segundos, lo cual truncaba los valores rápidos a 0).
+
+### Otras métricas expuestas
+
+* **Errores por endpoint:**
+  `http_endpoint_errors_total{endpoint="...",exception="..."}`
+* **Contadores de requests HTTP:**
+  `http_server_requests_seconds_count{method="POST",uri="/api/inference/query",...}`
+
+---
+
+## Controles de monitoreo recomendados
+
+1. **Verifica la recolección de métricas:**
+
+    * Ingresa a `/actuator/metrics` y buscá nombres como `http.endpoint.duration` y `http.endpoint.errors`.
+2. **Verifica la exportación:**
+
+    * Chequeá los logs para asegurarte que Micrometer intenta exportar a Dynatrace (aunque esté caído, verás `Failed metric ingestion`).
+    * Si usás Prometheus, podés scrapear `/actuator/prometheus`.
+3. **Forzá requests y errores:**
+
+    * Usá Postman/curl sobre los endpoints principales y chequeá que los contadores suban.
+    * Forzá un error y verificá que la métrica de errores sube.
+
+---
+
+## Endpoint de monitoreo unificado
+
+Existe un endpoint de monitoreo agregado para resumir la actividad de los tres controllers principales:
+
+```
+GET http://localhost:8081/api/monitoring/summary
+```
+
+Devuelve un JSON con las llamadas y tiempos totales/promedio de cada endpoint principal (¡ahora con tiempos reales en milisegundos!):
+
+```json
+{
+  "embedding": { "calls": 3, "total_seconds": 123, "mean_seconds": 41 },
+  "inference": { "calls": 7, "total_seconds": 980, "mean_seconds": 140 },
+  "llm": { "calls": 5, "total_seconds": 50, "mean_seconds": 10 }
+}
+```
+
+**Nota:** Los valores `total_seconds` y `mean_seconds` están en **milisegundos**. Si un endpoint aún no recibió tráfico, responde ceros.
+
+---
+
+## Métodos clave del MonitoringSummaryController
+
+Asegura que los datos de las métricas se obtienen correctamente, incluso si el MeterRegistry no expone timers por cada tag de endpoint:
+
+```java
+@GetMapping("/summary")
+public ResponseEntity<Map<String, Object>> getSummary() {
+    Map<String, Object> summary = new HashMap<>();
+    summary.put("embedding", getStatsFromMeters("api.embedding.documents"));
+    summary.put("inference", getStatsFromMeters("api.inference.query"));
+    summary.put("llm", getStatsFromMeters("api.llm.getPrompt"));
+    return ResponseEntity.ok(summary);
+}
+
+private Map<String, Object> getStatsFromMeters(String endpointName) {
+    Map<String, Object> stats = new HashMap<>();
+    double count = 0, total = 0;
+    for (io.micrometer.core.instrument.Meter meter : meterRegistry.getMeters()) {
+        io.micrometer.core.instrument.Meter.Id id = meter.getId();
+        if ("http.endpoint.duration".equals(id.getName()) && endpointName.equals(id.getTag("endpoint"))) {
+            for (io.micrometer.core.instrument.Measurement m : meter.measure()) {
+                if (m.getStatistic().name().equalsIgnoreCase("COUNT")) count = m.getValue();
+                if (m.getStatistic().name().equalsIgnoreCase("TOTAL_TIME")) total = m.getValue();
+            }
+        }
+    }
+    double mean = count > 0 ? total / count : 0;
+    stats.put("calls", (long) count);
+    stats.put("total_milliseconds", total);
+    stats.put("mean_milliseconds", mean);
+    return stats;
+}
+```
+
+### Endpoint extra de debug
+
+Permite ver qué endpoints están instrumentados actualmente:
+
+```java
+@GetMapping("/debug")
+public ResponseEntity<List<String>> debugEndpoints() {
+    List<String> endpoints = meterRegistry.getMeters()
+            .stream()
+            .filter(m -> "http.endpoint.duration".equals(m.getId().getName()))
+            .map(m -> m.getId().getTag("endpoint"))
+            .distinct()
+            .toList();
+    return ResponseEntity.ok(endpoints);
+}
+```
+
+---
+
+## Troubleshooting
+
+* Si no ves las métricas custom:
+
+    * Asegurate de que hay tráfico hacia los endpoints (`curl` o Postman).
+    * Revisá la annotation `@MonitoredEndpoint` esté bien aplicada y la config de Actuator exponga `metrics` y `prometheus`.
+* Si Dynatrace no está disponible, la colección y exposición por Prometheus/Actuator funciona igual.
+
+---
+
+## Referencias
+
+* [Micrometer Docs](https://micrometer.io/docs)
+* [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/)
+* [Prometheus Docs](https://prometheus.io/docs/introduction/overview/)

--- a/rag/src/main/resources/application.yaml
+++ b/rag/src/main/resources/application.yaml
@@ -123,20 +123,27 @@ logging:
     org.hibernate.type.descriptor.sql: INFO
     org.hibernate.orm.jdbc.bind: INFO
     org.hibernate.engine.jdbc.spi: INFO
+    io.micrometer: INFO
+    org.springframework.boot.actuate: INFO
 
-# Configuración de Springdoc
-springdoc:
-  api-docs:
-    enabled: true
-  swagger-ui:
-    enabled: true
+
 
 management:
   endpoints:
     web:
       exposure:
-        include: "*"
-  cors:
-    allowed-origins: "*"
-    allowed-methods: "*"
-    allowed-headers: "*"
+        include: "health,info,metrics,prometheus"  # Habilita endpoints clave
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      dynatrace:
+        enabled: true
+        api-token: dummy-token   # Poné cualquier string para testeo
+        uri: http://localhost:14499/api/v2/metrics/ingest # O el que tengas apuntando a WireMock o Dynatrace
+        device-id: evolvai-dev
+        technology-type: spring-boot
+      prometheus:
+        enabled: true
+


### PR DESCRIPTION
Introduced Micrometer metrics for advanced monitoring with support for Prometheus and Dynatrace. Added `MonitoredEndpoint` annotation, `MonitoringSummaryController`, and updated Actuator configuration. Expanded dependencies to include necessary Micrometer and Jetty modules. Adjusted metric recording to use milliseconds for higher precision.