### PR TITLE
feat: add SSE exception handler for streaming endpoints

### DIFF
--- a/rag/src/main/java/org/shark/evolvai/inference/adapter/in/rest/RagExceptionHandler.java
+++ b/rag/src/main/java/org/shark/evolvai/inference/adapter/in/rest/RagExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,10 +27,20 @@ public class RagExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
+    // Handler para endpoints normales (JSON)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleGenericExceptions(Exception ex) {
         Map<String, String> error = new HashMap<>();
         error.put("error", ex.getMessage());
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // Handler para endpoints SSE (text/event-stream)
+    @ExceptionHandler(Exception.class)
+    @org.springframework.web.bind.annotation.ResponseBody
+    @org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @org.springframework.web.bind.annotation.RequestMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> handleSseExceptions(Exception ex) {
+        return Flux.just("Error: " + ex.getMessage());
     }
 }


### PR DESCRIPTION
Introduced an exception handler for Server-Sent Events (SSE) endpoints, ensuring error handling supports `text/event-stream` responses with WebFlux.