### PR TITLE
Fix quiz module compilation

### DIFF
--- a/quiz/src/main/java/org/shark/quizai/application/service/QuizService.java
+++ b/quiz/src/main/java/org/shark/quizai/application/service/QuizService.java
@@ -33,7 +33,7 @@ public class QuizService {
     public String processResponse(QuizResponseRequest request) {
         // Si tienes una entidad para respuestas, aquí deberías guardarla.
         // quizRepository.saveResponse(request); // Solo si implementas esto.
-        return inferenceClient.inferirResultado(request);
+        return inferenceClient.inferResult(request);
     }
 
     public List<String> listDocumentIds() {

--- a/quiz/src/main/java/org/shark/quizai/domain/model/QuizResponseRequest.java
+++ b/quiz/src/main/java/org/shark/quizai/domain/model/QuizResponseRequest.java
@@ -3,7 +3,60 @@ package org.shark.quizai.domain.model;
 import java.util.Map;
 
 public class QuizResponseRequest {
-    public String documentId;
-    public String usuario;
-    public Map<String, String> respuestas;
+    private String documentId;
+    private String usuario;
+    private Map<String, String> respuestas;
+
+    // Optional fields used when calling the inference service
+    private String query;
+    private String conversationId;
+    private String customPrompt;
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
+
+    public String getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(String usuario) {
+        this.usuario = usuario;
+    }
+
+    public Map<String, String> getRespuestas() {
+        return respuestas;
+    }
+
+    public void setRespuestas(Map<String, String> respuestas) {
+        this.respuestas = respuestas;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+
+    public void setConversationId(String conversationId) {
+        this.conversationId = conversationId;
+    }
+
+    public String getCustomPrompt() {
+        return customPrompt;
+    }
+
+    public void setCustomPrompt(String customPrompt) {
+        this.customPrompt = customPrompt;
+    }
 }

--- a/quiz/src/main/java/org/shark/quizai/infrastructure/InferenceClientImpl.java
+++ b/quiz/src/main/java/org/shark/quizai/infrastructure/InferenceClientImpl.java
@@ -1,7 +1,7 @@
 package org.shark.quizai.infrastructure;
 
-import org.shark.evolvai.inference.controller.RagQueryRequest;
-import org.shark.evolvai.inference.controller.QueryResponse;
+import org.shark.quizai.infrastructure.dto.RagQueryRequest;
+import org.shark.quizai.infrastructure.dto.QueryResponse;
 import org.shark.quizai.domain.model.QuizResponseRequest;
 import org.shark.quizai.domain.port.out.InferenceClient;
 import org.springframework.stereotype.Component;

--- a/quiz/src/main/java/org/shark/quizai/infrastructure/dto/QueryResponse.java
+++ b/quiz/src/main/java/org/shark/quizai/infrastructure/dto/QueryResponse.java
@@ -1,0 +1,36 @@
+package org.shark.quizai.infrastructure.dto;
+
+import java.util.List;
+
+/**
+ * Minimal response object returned by the RAG service.
+ */
+public class QueryResponse {
+    private String answer;
+    private List<Object> matches;
+    private String conversationId;
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public List<Object> getMatches() {
+        return matches;
+    }
+
+    public void setMatches(List<Object> matches) {
+        this.matches = matches;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+
+    public void setConversationId(String conversationId) {
+        this.conversationId = conversationId;
+    }
+}

--- a/quiz/src/main/java/org/shark/quizai/infrastructure/dto/RagQueryRequest.java
+++ b/quiz/src/main/java/org/shark/quizai/infrastructure/dto/RagQueryRequest.java
@@ -1,0 +1,81 @@
+package org.shark.quizai.infrastructure.dto;
+
+import java.util.Map;
+
+/**
+ * Minimal request object used to call the RAG service.
+ */
+public class RagQueryRequest {
+    private String query;
+    private String conversationId;
+    private int maxResults;
+    private double minSimilarity;
+    private boolean includeMatches;
+    private String customPrompt;
+    private String documentId;
+    private Map<String, String> contextMetadata;
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+
+    public void setConversationId(String conversationId) {
+        this.conversationId = conversationId;
+    }
+
+    public int getMaxResults() {
+        return maxResults;
+    }
+
+    public void setMaxResults(int maxResults) {
+        this.maxResults = maxResults;
+    }
+
+    public double getMinSimilarity() {
+        return minSimilarity;
+    }
+
+    public void setMinSimilarity(double minSimilarity) {
+        this.minSimilarity = minSimilarity;
+    }
+
+    public boolean isIncludeMatches() {
+        return includeMatches;
+    }
+
+    public void setIncludeMatches(boolean includeMatches) {
+        this.includeMatches = includeMatches;
+    }
+
+    public String getCustomPrompt() {
+        return customPrompt;
+    }
+
+    public void setCustomPrompt(String customPrompt) {
+        this.customPrompt = customPrompt;
+    }
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
+
+    public Map<String, String> getContextMetadata() {
+        return contextMetadata;
+    }
+
+    public void setContextMetadata(Map<String, String> contextMetadata) {
+        this.contextMetadata = contextMetadata;
+    }
+}


### PR DESCRIPTION
## Summary
- add local `RagQueryRequest` and `QueryResponse` DTOs
- update `InferenceClientImpl` to use new DTOs
- expand `QuizResponseRequest` with accessors and optional fields
- fix method name in `QuizService`

## Testing
- `mvn -q -DskipTests=false test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f910bcbc832ebcec65c87cff3618